### PR TITLE
Endrer alerts slik til å bruke GCP spesifikke spørringer

### DIFF
--- a/dev-gcp-alerts.yml
+++ b/dev-gcp-alerts.yml
@@ -11,7 +11,7 @@ spec:
       channel: '#digisos-alerts-dev'
   alerts:
     - alert: digisos-app-nede
-      expr: kube_deployment_status_replicas_available{app=~"okonomi-gjeldsradgivning-veiviser"} == 0
+      expr: kube_deployment_status_replicas_available{deployment=~"okonomi-gjeldsradgivning-veiviser"} == 0
       for: 2m
       description: "{{ $labels.deployment }} er nede i {{ $labels.namespace }}"
       action: "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger"
@@ -25,10 +25,7 @@ spec:
       sla: respond within 1h, during office hours
       severity: danger
     - alert: høy feilrate i logger
-      expr: (100 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_app=~"okonomi-gjeldsradgivning-veiviser",log_level=~"Warning|Error"}[3m])) / sum by (log_app, log_namespace) (rate(logd_messages_total{log_app="<appname>"}[3m]))) > 10
+      expr: (100 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_app=~"okonomi-gjeldsradgivning-veiviser",log_level=~"Warning|Error"}[3m])) / sum by (log_app, log_namespace) (rate(logd_messages_total{log_app="okonomi-gjeldsradgivning-veiviser"}[3m]))) > 10
       for: 3m
       action: "Sjekk loggene til app {{ $labels.log_app }} i namespace {{ $labels.log_namespace }}, for å se hvorfor det er så mye feil"
-    - alert: feil i selftest
-      expr: selftests_aggregate_result_status{app=~"okonomi-gjeldsradgivning-veiviser"} > 0
-      for: 1m
-      action: "Sjekk app {{ $labels.app }} i namespace {{ $labels.kubernetes_namespace }} sine selftest for å se hva som er galt"
+


### PR DESCRIPTION
Parameteret `app` i `kube_deployment_status_replicas_available` ser ut til å være byttet ut med `deployment` i dev-gcp.

La til manglende `log_app` for spørring mot logger.