### PR TITLE
kun kritiske feil trigger selftest-alert

### DIFF
--- a/prod-sbs-alerts.yml
+++ b/prod-sbs-alerts.yml
@@ -31,7 +31,7 @@ spec:
       action: "Sjekk loggene til app {{ $labels.log_app }} for å se hvorfor det er så mye feil"
       description: "Høy feilrate i {{ $labels.log_app }}"
     - alert: feil i selftest
-      expr: selftests_aggregate_result_status{kubernetes_namespace="teamdigisos"} > 0
+      expr: selftests_aggregate_result_status{kubernetes_namespace="teamdigisos"} == 1
       for: 1m
       action: "Sjekk {{ $labels.app }} i prod-sbs sin selftest for å se hva som er galt"
       description: "Feil i selftest - {{ $labels.app }} i prod-sbs"


### PR DESCRIPTION
Samme som i dev-sbs, prod-fss og dev-fss

selftests_aggregate_result_status == 0  --> Alt Ok
selftests_aggregate_result_status == 1 --> kritisk feil
selftests_aggregate_result_status == 2  --> ikke-kritisk feil