### PR TITLE
Fix alerts for prod-gcp

### DIFF
--- a/prod-gcp-alerts.yml
+++ b/prod-gcp-alerts.yml
@@ -11,21 +11,21 @@ spec:
       channel: '#digisos-alerts'
   alerts:
     - alert: digisos-app-nede
-      expr: kube_deployment_status_replicas_available{deployment=~"okonomi-gjeldsradgivning-veiviser|sosialhjelp-dialog-bruker|sosialhjelp-dialog-veileder|sosialhjelp-dialog-api"} == 0
+      expr: kube_deployment_status_replicas_available{deployment=~"sosialhjelp-dialog-bruker|sosialhjelp-dialog-veileder|sosialhjelp-dialog-api"} == 0
       for: 2m
       description: "{{ $labels.deployment }} er nede i prod-gcp"
       action: "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger"
       sla: respond within 1h, during office hours
       severity: danger
     - alert: digisos-app-kontinuerlig-restart
-      expr: sum(increase(kube_pod_container_status_restarts_total{container=~"okonomi-gjeldsradgivning-veiviser|sosialhjelp-dialog-bruker|sosialhjelp-dialog-veileder|sosialhjelp-dialog-api"}[30m])) by (container) > 2
+      expr: sum(increase(kube_pod_container_status_restarts_total{container=~"sosialhjelp-dialog-bruker|sosialhjelp-dialog-veileder|sosialhjelp-dialog-api"}[30m])) by (container) > 2
       for: 5m
       description: "{{ $labels.container }} har restartet flere ganger siste halvtimen!"
       action: "Se `kubectl describe pod {{ $labels.container }}` for events, og `kubectl logs {{ $labels.container }}` for logger"
       sla: respond within 1h, during office hours
       severity: danger
     - alert: høy feilrate i logger
-      expr: (600 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_app=~"okonomi-gjeldsradgivning-veiviser|sosialhjelp-dialog-bruker|sosialhjelp-dialog-veileder|sosialhjelp-dialog-api",log_level=~"Warning|Error"}[10m]))) > 10
+      expr: (600 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_app=~"sosialhjelp-dialog-bruker|sosialhjelp-dialog-veileder|sosialhjelp-dialog-api",log_level=~"Error"}[10m]))) > 10
       for: 10m
       action: "Sjekk loggene til app {{ $labels.log_app }} for å se hvorfor det er så mye feil"
       description: "Høy feilrate i logger på app {{ $labels.log_app }}"


### PR DESCRIPTION
Feilrate-alert sjekker nå kun Error-logger.
Fjerner øk.veiviser fra alertene