### PR TITLE
Fix alerts for dev-gcp

### DIFF
--- a/dev-gcp-alerts.yml
+++ b/dev-gcp-alerts.yml
@@ -11,21 +11,21 @@ spec:
       channel: '#digisos-alerts-dev'
   alerts:
     - alert: digisos-app-nede
-      expr: kube_deployment_status_replicas_available{deployment=~"okonomi-gjeldsradgivning-veiviser-dev|sosialhjelp-dialog-bruker-dev|sosialhjelp-dialog-veileder-dev|sosialhjelp-dialog-api-dev|sosialhjelp-soknad-api-dev|sosialhjelp-soknad-dev|sosialhjelp-login-api-dev|sosialhjelp-innsyn-api-dev|sosialhjelp-innsyn-dev"} == 0
+      expr: kube_deployment_status_replicas_available{deployment=~"sosialhjelp-dialog-bruker-dev|sosialhjelp-dialog-veileder-dev|sosialhjelp-dialog-api-dev|sosialhjelp-soknad-api-dev|sosialhjelp-soknad-dev|sosialhjelp-login-api-dev|sosialhjelp-innsyn-api-dev|sosialhjelp-innsyn-dev"} == 0
       for: 2m
       description: "{{ $labels.deployment }} er nede i dev-gcp"
       action: "Se `kubectl describe pod {{ $labels.kubernetes_pod_name }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }}` for logger"
       sla: respond within 1h, during office hours
       severity: danger
     - alert: digisos-app-kontinuerlig-restart
-      expr: sum(increase(kube_pod_container_status_restarts_total{container=~"okonomi-gjeldsradgivning-veiviser-dev|sosialhjelp-dialog-bruker-dev|sosialhjelp-dialog-veileder-dev|sosialhjelp-dialog-api-dev|sosialhjelp-soknad-api-dev|sosialhjelp-soknad-dev|sosialhjelp-login-api-dev|sosialhjelp-innsyn-api-dev|sosialhjelp-innsyn-dev"}[30m])) by (container) > 2
+      expr: sum(increase(kube_pod_container_status_restarts_total{container=~"sosialhjelp-dialog-bruker-dev|sosialhjelp-dialog-veileder-dev|sosialhjelp-dialog-api-dev|sosialhjelp-soknad-api-dev|sosialhjelp-soknad-dev|sosialhjelp-login-api-dev|sosialhjelp-innsyn-api-dev|sosialhjelp-innsyn-dev"}[30m])) by (container) > 2
       for: 5m
       description: "{{ $labels.container }} har restartet flere ganger siste halvtimen!"
       action: "Se `kubectl describe pod {{ $labels.container }}` for events, og `kubectl logs {{ $labels.container }}` for logger"
       sla: respond within 1h, during office hours
       severity: danger
     - alert: høy feilrate i logger
-      expr: (100 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_app=~"okonomi-gjeldsradgivning-veiviser-dev|sosialhjelp-dialog-bruker-dev|sosialhjelp-dialog-veileder-dev|sosialhjelp-dialog-api-dev|sosialhjelp-soknad-api-dev|sosialhjelp-soknad-dev|sosialhjelp-login-api-dev|sosialhjelp-innsyn-api-dev|sosialhjelp-innsyn-dev",log_level=~"Warning|Error"}[10m]))) > 10
+      expr: (100 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_app=~"sosialhjelp-dialog-bruker-dev|sosialhjelp-dialog-veileder-dev|sosialhjelp-dialog-api-dev|sosialhjelp-soknad-api-dev|sosialhjelp-soknad-dev|sosialhjelp-login-api-dev|sosialhjelp-innsyn-api-dev|sosialhjelp-innsyn-dev",log_level=~"Error"}[10m]))) > 10
       for: 3m
       action: "Sjekk loggene til app {{ $labels.log_app }} for å se hvorfor det er så mye feil"
       description: "Høy feilrate i logger på app {{ $labels.log_app }}"


### PR DESCRIPTION
Feil-rate logger sjekker kun Error-logger.
Fjerner øk.veiviser, siden den er tatt ned