### PR TITLE
Legger til en regel for lav requestrate

### DIFF
--- a/prod-fss-alerts.yml
+++ b/prod-fss-alerts.yml
@@ -46,3 +46,9 @@ spec:
             summary: "Feil i selftest - {{ $labels.app }} i prod-fss"
           labels:
             namespace: teamdigisos
+        - alert: drastisk nedgang i bruk av soknad-api
+          expr: 1 / (sum(predict_linear(http_server_requests_seconds_count{app="sosialhjelp-soknad-api", uri=~"/soknader.*"}[20m], 1800)) / sum(avg_over_time(http_server_requests_seconds_count{app="sosialhjelp-soknad-api"}[30m]))) > 60.0
+          for: 5m
+          annotations:
+              action: "Sjekk om sosialhjelp-soknad og/eller login-service er i drift"
+              summary: "Drastisk fall i requests mot soknad-api /soknader"

--- a/prod-fss-alerts.yml
+++ b/prod-fss-alerts.yml
@@ -46,9 +46,30 @@ spec:
             summary: "Feil i selftest - {{ $labels.app }} i prod-fss"
           labels:
             namespace: teamdigisos
-        - alert: drastisk nedgang i bruk av soknad-api
-          expr: 1 / (sum(predict_linear(http_server_requests_seconds_count{app="sosialhjelp-soknad-api", uri=~"/soknader.*"}[20m], 1800)) / sum(avg_over_time(http_server_requests_seconds_count{app="sosialhjelp-soknad-api"}[30m]))) > 60.0
+        - alert: drastisk nedgang i requests til soknad-api
+          expr: |
+            1 / (
+              sum(predict_linear(
+                http_server_requests_seconds_count{
+                  app="sosialhjelp-soknad-api", 
+                  uri=~"/soknader.*"
+                }[20m], 1800)
+              ) / sum(
+                avg_over_time(
+                  http_server_requests_seconds_count{
+                    app="sosialhjelp-soknad-api"
+                  }[30m]
+                )
+              )
+            ) > 60.0
           for: 1m
           annotations:
+              summary: "API-kall mot soknad-api synker svært raskt"
               action: "Sjekk om sosialhjelp-soknad og/eller login-service er i drift"
-              summary: "Drastisk fall i requests mot soknad-api /soknader"
+              consequence: "Det kan være problemer med sosialhjelp-soknad frontend, sjekk https://nav.no/sosialhjelp/soknad"
+              message: |
+                Forespørsler mot soknad-api synker svært raskt.
+                Dette varselet sammenligner forventet trafikk fra trenden for de siste 20 minutter med faktisk trafikk de siste 30 minuttene.
+                Varselet utløses hvis den forutsagte trafikken er mindre enn 1/60 av gjennomsnittet for siste halvtime.
+          labels:
+            namespace: teamdigisos

--- a/prod-fss-alerts.yml
+++ b/prod-fss-alerts.yml
@@ -48,7 +48,7 @@ spec:
             namespace: teamdigisos
         - alert: drastisk nedgang i bruk av soknad-api
           expr: 1 / (sum(predict_linear(http_server_requests_seconds_count{app="sosialhjelp-soknad-api", uri=~"/soknader.*"}[20m], 1800)) / sum(avg_over_time(http_server_requests_seconds_count{app="sosialhjelp-soknad-api"}[30m]))) > 60.0
-          for: 5m
+          for: 1m
           annotations:
               action: "Sjekk om sosialhjelp-soknad og/eller login-service er i drift"
               summary: "Drastisk fall i requests mot soknad-api /soknader"


### PR DESCRIPTION
Etter nedetiden med sosialhjelp-soknad prøvde jeg å finne en god metrikk som kan gi oss et hint dersom frontend ikke fungerer. Dette er formelen jeg kom frem til for et godt signal dersom frontend går ned.